### PR TITLE
Remove useless println!

### DIFF
--- a/src/fast_marcher.rs
+++ b/src/fast_marcher.rs
@@ -76,8 +76,6 @@ impl Grid {
             }
         }
 
-        println!("boundary size: {}", boundary.len());
-
         boundary
     }
 }


### PR DESCRIPTION
Pretty self-explanatory. `edt_fmm` prints messages like `boundary size: 2890` to console, which is bad for a library.